### PR TITLE
feat: persist client credentials

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,17 @@
             const googleAuthUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
 
             let clientId = localStorage.getItem('googleClientId');
+            let clientSecret = localStorage.getItem('googleClientSecret');
             let accessToken = localStorage.getItem('googleAccessToken');
+
+            // If credentials are already stored, hide the file input since re-upload isn't needed
+            if (clientId && clientSecret) {
+                credentialsFileInput.style.display = 'none';
+                const authMessage = authSection.querySelector('p');
+                if (authMessage) {
+                    authMessage.textContent = 'Click the "Authenticate with Google" button to continue.';
+                }
+            }
 
             // Function to check for an access token in the URL hash on page load
             function checkUrlForToken() {
@@ -123,6 +133,12 @@
 
             // Event listener for reading and saving the JSON credentials file
             authenticateButton.addEventListener('click', () => {
+                // If credentials are already stored, use them directly
+                if (clientId && clientSecret) {
+                    initiateOAuthFlow(clientId);
+                    return;
+                }
+
                 const file = credentialsFileInput.files[0];
                 if (!file) {
                     alert('Please select a JSON file to upload.');
@@ -134,15 +150,18 @@
                     try {
                         const credentials = JSON.parse(event.target.result);
                         clientId = credentials.web.client_id;
-                        
-                        if (clientId) {
+                        clientSecret = credentials.web.client_secret;
+
+                        if (clientId && clientSecret) {
                             localStorage.setItem('googleClientId', clientId);
+                            localStorage.setItem('googleClientSecret', clientSecret);
+                            credentialsFileInput.style.display = 'none';
                             initiateOAuthFlow(clientId);
                         } else {
-                            alert('Invalid credentials file format. Please ensure it contains "web.client_id".');
+                            alert('Invalid credentials file format. Please ensure it contains "web.client_id" and "web.client_secret".');
                         }
                     } catch (e) {
-                        alert('Failed to parse JSON file or find credentials at "web.client_id".');
+                        alert('Failed to parse JSON file or find credentials at "web.client_id" and "web.client_secret".');
                     }
                 };
                 reader.readAsText(file);
@@ -156,9 +175,9 @@
                     fetchCalendarEvents();
                     // Refresh every minute to update the time
                     setInterval(fetchCalendarEvents, 60 * 1000);
-                } else if (clientId) {
-                    // Show a message if client ID is set but token isn't, and trigger auth
-                    alert('Please click the "Authenticate with Google" button to complete the sign-in process.');
+                } else if (clientId && clientSecret) {
+                    authSection.style.display = 'block';
+                    eventsDashboard.style.display = 'none';
                 }
             }
 


### PR DESCRIPTION
## Summary
- store Google OAuth client secret alongside client ID in localStorage
- reuse stored credentials for authentication and adjust messaging when both are present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ce911d80832faa5f18f72534ae37