### PR TITLE
Handle expired Google Calendar tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,8 +199,11 @@
                             'Authorization': `Bearer ${accessToken}`
                         }
                     });
+                    if (!response.ok) {
+                        throw new Error(`HTTP error ${response.status}`);
+                    }
                     const data = await response.json();
-                    
+
                     if (data.items) {
                         displayEvents(data.items);
                     } else {


### PR DESCRIPTION
## Summary
- check fetch responses for authorization errors when loading calendar events
- prompt users to re-authenticate if the calendar API call fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896cff83f64832f90b6968d47385088