### PR TITLE
Show raw minute count on non-phone devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,10 +252,16 @@
                 if (deltaMinutes <= 0) {
                     return 'Event in progress';
                 }
-                
+
+                // On non-phone devices, return the raw number of minutes without unit labels
+                const isPhone = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+                if (!isPhone) {
+                    return Math.round(deltaMinutes).toLocaleString('fullwide', { useGrouping: false });
+                }
+
                 const log2Minutes = Math.log2(deltaMinutes);
                 const roundedLog2 = log2Minutes.toFixed(1);
-                
+
                 let formattedTime;
                 if (roundedLog2 >= 10.0) {
                     const integerPart = Math.floor(roundedLog2);
@@ -265,7 +271,7 @@
                 } else {
                     formattedTime = `${roundedLog2} [log2]min`;
                 }
-                
+
                 return formattedTime;
             }
 


### PR DESCRIPTION
## Summary
- Return raw minute count on non-phone devices instead of formatted text
- Ensure minutes are displayed without scientific notation

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Log2Calculator/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a8092852b4832fbc8813ff3c7c429a